### PR TITLE
Fix for regression in Memory; index not always rebuilt

### DIFF
--- a/store/Memory.js
+++ b/store/Memory.js
@@ -197,6 +197,11 @@ return declare("dojo.store.Memory", base, {
 		var i;
 
 		startIndex = startIndex || 0;
+		
+		// clear index first
+		this.index = {};
+		
+		// now rebuild index
 		for(i = startIndex; i < dataLength; i++){
 			this.index[data[i][this.idProperty]] = i;
 		}


### PR DESCRIPTION
After using the just released 1.17.0 version, i got regression in one of our unit tests regarding memory stores.

- When rebuilding the index, items that were removed from the store are not purged from the index.
- This causes invalid behavior when retrieving an item after removing an item
- Regression of https://github.com/dojo/dojo/commit/13711ff3e659cf17d9a9a6d48d4ae7b076e8bc71, where `setData` used to clear the index when called from the `remove` method, but no longer does now.

Added a workaround in our own code:
```
      dojo.store.Memory.prototype._rebuildIndex = function(startIndex) {
        const data = this.data;
        const dataLength = data.length;
        let i;

        startIndex = startIndex || 0;

        // clear index
        this.index = {};

        // now rebuild
        for (i = startIndex; i < dataLength; i++) {
          this.index[data[i][this.idProperty]] = i;
        }
      };
```